### PR TITLE
Allowing clusters with zero pcs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: varclust
 Type: Package
 Title: Variables Clustering
-Version: 0.9.5
-Date: 2020-03-08
+Version: 0.10.0
+Date: 2021-05-12
 Author: Piotr Sobczyk, Stanislaw Wilczynski, Julie Josse, Malgorzata Bogdan
 Maintainer: Piotr Sobczyk <pj.sobczyk@gmail.com>
 Description: Performs clustering of quantitative variables,

--- a/R/auxiliary.functions.R
+++ b/R/auxiliary.functions.R
@@ -97,7 +97,7 @@ choose.cluster.BIC <- function(variable, pcas, number.clusters, show.warnings = 
       BICs[i] <- loglik - nparams * log(n) / 2
     }
   }
-  which.max(BICs)
+  return(which.max(BICs))
 }
 
 #' Calculates principal components for every cluster

--- a/R/auxiliary.functions.R
+++ b/R/auxiliary.functions.R
@@ -38,7 +38,8 @@ cluster.pca.BIC <- function(X, segmentation, dims, numb.clusters, max.dim, flat.
         method = "heterogenous"
       )$vals[1]
     } else {
-      warning("The dimensionality of the cluster was greater or equal than max(number of observation, number of variables) in the cluster.
+      warning("The dimensionality of the cluster was greater or equal than
+              max(number of observation, number of variables) in the cluster.
               Ignoring the cluster during mBIC calculation")
       formula[k] <- 0
     }
@@ -53,7 +54,7 @@ cluster.pca.BIC <- function(X, segmentation, dims, numb.clusters, max.dim, flat.
   return(BIC)
 }
 
-#' Choses a subspace for a variable
+#' Chooses a subspace for a variable
 #'
 #' Selects a subspace closest to a given variable. To select the subspace, the method
 #' considers (for every subspace) a subset of its principal components and tries
@@ -71,7 +72,7 @@ cluster.pca.BIC <- function(X, segmentation, dims, numb.clusters, max.dim, flat.
 choose.cluster.BIC <- function(variable, pcas, number.clusters, show.warnings = FALSE, common_sigma = TRUE) {
   BICs <- NULL
   if (common_sigma) {
-    res <- fastLmPure(as.matrix(Matrix::bdiag(pcas)), rep(variable, number.clusters), method = 0L)$residuals
+    res <- fastLmPure(cbind(1, as.matrix(Matrix::bdiag(pcas))), rep(variable, number.clusters), method = 0L)$residuals
     n <- length(variable)
     sigma.hat <- sqrt(sum(res^2) / (n * number.clusters))
     if (sigma.hat < 1e-15 && show.warnings) {
@@ -120,14 +121,14 @@ calculate.pcas <- function(X, segmentation, number.clusters, max.subspace.dim, e
       a <- summary(prcomp(x = Xk))
       if (estimate.dimensions) {
         max.dim <- min(max.subspace.dim, floor(sqrt(sub.dim[2])), sub.dim[1])
-        cut <- max(1, pesel(
-          X = Xk, npc.min = 1, npc.max = max.dim, scale = FALSE,
+        cut <- max(0, pesel(
+          X = Xk, npc.min = 0, npc.max = max.dim, scale = FALSE,
           method = "heterogenous"
         )$nPCs)
       } else {
         cut <- min(max.subspace.dim, floor(sqrt(sub.dim[2])), sub.dim[1])
       }
-      return(matrix(a$x[, 1:cut], nrow = rowNumb))
+      return(matrix(a$x[, seq_len(cut)], nrow = rowNumb))
     } else {
       return(matrix(rnorm(rowNumb), nrow = rowNumb, ncol = 1))
     }

--- a/R/auxiliary.functions.R
+++ b/R/auxiliary.functions.R
@@ -129,7 +129,7 @@ calculate.pcas <- function(X, segmentation, number.clusters, max.subspace.dim, e
         cut <- min(max.subspace.dim, floor(sqrt(sub.dim[2])), sub.dim[1])
       }
       return(matrix(a$x[, seq_len(cut)], nrow = rowNumb))
-    } else {
+    } else { #if there are no variables initiate a cluster at random
       return(matrix(rnorm(rowNumb), nrow = rowNumb, ncol = 1))
     }
   })

--- a/R/varclust.R
+++ b/R/varclust.R
@@ -41,7 +41,7 @@
 #'
 #' @docType package
 #' @name varclust
-#' @details Version: 0.9.5
+#' @details Version: 0.10.0
 #' @importFrom RcppEigen fastLmPure
 #' @importFrom doParallel registerDoParallel
 #' @importFrom parallel makeCluster

--- a/tests/testthat/test_mlcc_kmeans.R
+++ b/tests/testthat/test_mlcc_kmeans.R
@@ -3,11 +3,10 @@ context("Testing mlcc.kmeans")
 library(varclust)
 
 test_that("when data is random we select dimension equal to 0", {
-  X <- with(set.seed(23), matrix(rnorm(1000), ncol=20))
-  mlcc.res <- mlcc.kmeans(X, number.clusters = 2,
+  X <- with(set.seed(10), matrix(rnorm(1000), ncol=20))
+  mlcc.res <- mlcc.kmeans(X, number.clusters = 1,
                           max.iter = 20, max.subspace.dim = 3)
-  expect_equal(length(unique(mlcc.res$segmentation)), 1)
-  expect_equal(ncol(mlcc.res$pcas[[mlcc.res$segmentation[1]]]), 0)
+  expect_equal(ncol(mlcc.res$pcas[[1]]), 0)
 })
 
 

--- a/tests/testthat/test_mlcc_kmeans.R
+++ b/tests/testthat/test_mlcc_kmeans.R
@@ -2,6 +2,15 @@ context("Testing mlcc.kmeans")
 
 library(varclust)
 
+test_that("when data is random we select dimension equal to 0", {
+  X <- with(set.seed(23), matrix(rnorm(1000), ncol=20))
+  mlcc.res <- mlcc.kmeans(X, number.clusters = 2,
+                          max.iter = 20, max.subspace.dim = 3)
+  expect_equal(unique(mlcc.res$segmentation), 1)
+  expect_equal(ncol(mlcc.res$pcas[[mlcc.res$segmentation[1]]]), 0)
+})
+
+
 test_that("principal components returned by mlcc.kmeans are in fact principal components of the clusters", {
   set.seed(10)
   X <- data.simulation.factors(n = 20, K = 2, numb.vars = 50, numb.factors = 5)$X
@@ -17,17 +26,20 @@ test_that("principal components returned by mlcc.kmeans are in fact principal co
   expect_equal(real_pcas2, pcas[[2]])
 })
 
+
 test_that("incorrect length on initial segmentation", {
   load("test_data/small_matrix.rda")
   segmentation <- rep(1:2, each = 40)
   expect_error(mlcc.kmeans(X, number.clusters = 2, initial.segmentation = segmentation), "The lenght of initial*")
 })
 
+
 test_that("incorrect initial segmentation", {
   load("test_data/small_matrix.rda")
   segmentation <- rep(1:4, each = 25)
   expect_error(mlcc.kmeans(X, number.clusters = 2, initial.segmentation = segmentation), "Too many*")
 })
+
 
 test_that("perfect segmentation", {
   load("test_data/small_matrix.rda")

--- a/tests/testthat/test_mlcc_kmeans.R
+++ b/tests/testthat/test_mlcc_kmeans.R
@@ -6,7 +6,7 @@ test_that("when data is random we select dimension equal to 0", {
   X <- with(set.seed(23), matrix(rnorm(1000), ncol=20))
   mlcc.res <- mlcc.kmeans(X, number.clusters = 2,
                           max.iter = 20, max.subspace.dim = 3)
-  expect_equal(unique(mlcc.res$segmentation), 1)
+  expect_equal(length(unique(mlcc.res$segmentation)), 1)
   expect_equal(ncol(mlcc.res$pcas[[mlcc.res$segmentation[1]]]), 0)
 })
 


### PR DESCRIPTION
Currently each cluster needs to be of at least dimension 1. However when data is random we expect the dimension to be equal 0, as there is no underlying latent structure.